### PR TITLE
adding possibility to give project_id as parameter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst') as f:
 
 setup(
     name='bigquery',
-    version='0.0.23',
+    version='0.0.24',
     description='Easily send data to Big Query',
     long_description=readme,
     author='Dacker',


### PR DESCRIPTION
+ change naming of former custom_connection parameter

Tested on Richemont (without giving project_id) and it functioned