### PR TITLE
Fix Error when importing Floats in the form "x.0" with x an integer

### DIFF
--- a/bigquery/core/Column.py
+++ b/bigquery/core/Column.py
@@ -136,12 +136,9 @@ def find_sample_value(df, name, i):
         df1 = df1.apply(lambda x: convert_to_bool(x))
     except:
         try:
-            df1 = df1.apply(lambda x: convert_to_int(x))
+            df1 = df1.apply(lambda x: float(x))
         except:
-            try:
-                df1 = df1.apply(lambda x: float(x))
-            except:
-                pass
+            pass
     df1_copy = copy.deepcopy(df1)
     if df1.dtype == 'object':
         df1 = df1.apply(lambda x: (str(x.encode()) if isinstance(x, str) else x) if x is not None else '')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst') as f:
 
 setup(
     name='bigquery',
-    version='0.0.24',
+    version='0.0.25',
     description='Easily send data to Big Query',
     long_description=readme,
     author='Dacker',


### PR DESCRIPTION
When importing a new table which has a column full of values in the form x.0 where x is in an integer, bigquery load throws an error, because the package was trying to convert this column to INT64 type instead of FLOAT64.

To solve this, we removed the usage of the `convert_to_int` function inside `find_sample_value`, which now leads to such Floats being inferred as FLOAT64 type instead of INT64.